### PR TITLE
Fix and make optional the GNOME screen lock removal on RHEL hosts

### DIFF
--- a/custom_script_extensions/Configure-RHEL7-Host.sh
+++ b/custom_script_extensions/Configure-RHEL7-Host.sh
@@ -38,14 +38,33 @@ create_user_script_url="$script_source_root/linux_host/create-user.sh"
 create_user_script="/usr/local/bin/create-user.sh"
 manage_lease_script_url="$script_source_root/linux_host/manage-lease.sh"
 manage_lease_script="/usr/local/bin/manage-lease.sh"
+screensaver_settings_url="$script_source_root/linux_host/session_release_buffer/RHEL/00-screensaver"
+screensaver_locks_url="$script_source_root/linux_host/session_release_buffer/RHEL/screensaver"
 
 arch=$( /bin/arch )
 remoteAccessTool="both"  # Options: "xrdp", "xpra", or "both"
+
+# Disable the GNOME screen saver and screen lock on this host. Enabled by default because a
+# locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which
+# strands the host's lease. Set LINUXBROKER_DISABLE_SCREEN_LOCK=false to keep the lock screen.
+disableScreenLock="${LINUXBROKER_DISABLE_SCREEN_LOCK:-true}"
+disableScreenLock=$(printf '%s' "$disableScreenLock" | tr '[:upper:]' '[:lower:]')
+
+case "$disableScreenLock" in
+    true|1|yes|y) disableScreenLock="true" ;;
+    false|0|no|n) disableScreenLock="false" ;;
+    *)
+        echo "Unsupported LINUXBROKER_DISABLE_SCREEN_LOCK value: $disableScreenLock (expected true or false)"
+        exit 1
+        ;;
+esac
 
 orgId="${RHEL_ORG_ID:-}"
 activationKey="${RHEL_ACTIVATION_KEY:-}"
 
 output_directory="/usr/local/bin"
+dconf_local_directory="/etc/dconf/db/local.d"
+dconf_profile_file="/etc/dconf/profile/user"
 state_directory="/var/lib/linuxbroker-release-session"
 
 SCRIPT_PATH="$output_directory/release-session.sh"
@@ -284,5 +303,50 @@ else
     exit 1
 fi
 echo "avdadmin user is created and permissioned"
+
+# Disable screen lock on Gnome desktop
+if [ "$disableScreenLock" = "true" ]; then
+    echo "Disabling the Gnome Desktop screen saver and screen lock..."
+
+    sudo mkdir -p "$dconf_local_directory/locks"
+
+    echo "Downloading Gnome Desktop screen lock settings..."
+    if ! sudo wget -O "$dconf_local_directory/00-screensaver" "$screensaver_settings_url"; then
+        echo "ERROR: Failed to download screen lock settings from $screensaver_settings_url"
+        exit 1
+    fi
+
+    if ! sudo wget -O "$dconf_local_directory/locks/screensaver" "$screensaver_locks_url"; then
+        echo "ERROR: Failed to download screen lock overrides from $screensaver_locks_url"
+        exit 1
+    fi
+
+    sudo chmod 644 "$dconf_local_directory/00-screensaver" "$dconf_local_directory/locks/screensaver"
+
+    # A system dconf database is only consulted when a profile references it. RHEL does not
+    # ship /etc/dconf/profile/user, so without this the settings above are silently ignored.
+    sudo mkdir -p "$(dirname "$dconf_profile_file")"
+    if [ ! -s "$dconf_profile_file" ]; then
+        printf 'user-db:user\nsystem-db:local\n' | sudo tee "$dconf_profile_file" >/dev/null
+        echo "Created dconf profile $dconf_profile_file."
+    elif ! grep -qx 'system-db:local' "$dconf_profile_file"; then
+        # Guarantee a trailing newline before appending to an existing profile.
+        sudo sed -i -e '$a\' "$dconf_profile_file"
+        echo 'system-db:local' | sudo tee -a "$dconf_profile_file" >/dev/null
+        echo "Added system-db:local to existing dconf profile $dconf_profile_file."
+    else
+        echo "dconf profile $dconf_profile_file already references system-db:local."
+    fi
+    sudo chmod 644 "$dconf_profile_file"
+
+    if ! sudo dconf update; then
+        echo "ERROR: 'dconf update' failed; the screen lock settings were not applied."
+        exit 1
+    fi
+
+    echo "Gnome Desktop screen lock is disabled."
+else
+    echo "Skipping Gnome Desktop screen lock configuration (LINUXBROKER_DISABLE_SCREEN_LOCK=false)."
+fi
 
 echo "System configuration complete."

--- a/custom_script_extensions/Configure-RHEL8-Host.sh
+++ b/custom_script_extensions/Configure-RHEL8-Host.sh
@@ -62,11 +62,27 @@ xrdp_ini="/etc/xrdp/xrdp.ini"
 arch=$( /bin/arch )
 remoteAccessTool="both"  # Options: "xrdp", "xpra", or "both"
 
+# Disable the GNOME screen saver and screen lock on this host. Enabled by default because a
+# locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which
+# strands the host's lease. Set LINUXBROKER_DISABLE_SCREEN_LOCK=false to keep the lock screen.
+disableScreenLock="${LINUXBROKER_DISABLE_SCREEN_LOCK:-true}"
+disableScreenLock=$(printf '%s' "$disableScreenLock" | tr '[:upper:]' '[:lower:]')
+
+case "$disableScreenLock" in
+    true|1|yes|y) disableScreenLock="true" ;;
+    false|0|no|n) disableScreenLock="false" ;;
+    *)
+        echo "Unsupported LINUXBROKER_DISABLE_SCREEN_LOCK value: $disableScreenLock (expected true or false)"
+        exit 1
+        ;;
+esac
+
 orgId="${RHEL_ORG_ID:-}"
 activationKey="${RHEL_ACTIVATION_KEY:-}"
 
 output_directory="/usr/local/bin"
 dconf_local_directory="/etc/dconf/db/local.d"
+dconf_profile_file="/etc/dconf/profile/user"
 state_directory="/var/lib/linuxbroker-release-session"
 
 SCRIPT_PATH="$output_directory/release-session.sh"
@@ -310,10 +326,49 @@ fi
 echo "avdadmin user is created and permissioned"
 
 # Disable screen lock on Gnome desktop
-echo "Downloading Gnome Desktop screen lock settings..."
-sudo wget -O "$dconf_local_directory/00-screensaver" "$screensaver_settings_url"
-sudo wget -O "$dconf_local_directory/locks/screensaver" "$screensaver_locks_url"
-sudo dconf update
+if [ "$disableScreenLock" = "true" ]; then
+    echo "Disabling the Gnome Desktop screen saver and screen lock..."
+
+    sudo mkdir -p "$dconf_local_directory/locks"
+
+    echo "Downloading Gnome Desktop screen lock settings..."
+    if ! sudo wget -O "$dconf_local_directory/00-screensaver" "$screensaver_settings_url"; then
+        echo "ERROR: Failed to download screen lock settings from $screensaver_settings_url"
+        exit 1
+    fi
+
+    if ! sudo wget -O "$dconf_local_directory/locks/screensaver" "$screensaver_locks_url"; then
+        echo "ERROR: Failed to download screen lock overrides from $screensaver_locks_url"
+        exit 1
+    fi
+
+    sudo chmod 644 "$dconf_local_directory/00-screensaver" "$dconf_local_directory/locks/screensaver"
+
+    # A system dconf database is only consulted when a profile references it. RHEL does not
+    # ship /etc/dconf/profile/user, so without this the settings above are silently ignored.
+    sudo mkdir -p "$(dirname "$dconf_profile_file")"
+    if [ ! -s "$dconf_profile_file" ]; then
+        printf 'user-db:user\nsystem-db:local\n' | sudo tee "$dconf_profile_file" >/dev/null
+        echo "Created dconf profile $dconf_profile_file."
+    elif ! grep -qx 'system-db:local' "$dconf_profile_file"; then
+        # Guarantee a trailing newline before appending to an existing profile.
+        sudo sed -i -e '$a\' "$dconf_profile_file"
+        echo 'system-db:local' | sudo tee -a "$dconf_profile_file" >/dev/null
+        echo "Added system-db:local to existing dconf profile $dconf_profile_file."
+    else
+        echo "dconf profile $dconf_profile_file already references system-db:local."
+    fi
+    sudo chmod 644 "$dconf_profile_file"
+
+    if ! sudo dconf update; then
+        echo "ERROR: 'dconf update' failed; the screen lock settings were not applied."
+        exit 1
+    fi
+
+    echo "Gnome Desktop screen lock is disabled."
+else
+    echo "Skipping Gnome Desktop screen lock configuration (LINUXBROKER_DISABLE_SCREEN_LOCK=false)."
+fi
 
 # Complete
 echo "System configuration complete."

--- a/custom_script_extensions/Configure-RHEL9-Host.sh
+++ b/custom_script_extensions/Configure-RHEL9-Host.sh
@@ -36,14 +36,33 @@ create_user_script_url="$script_source_root/linux_host/create-user.sh"
 create_user_script="/usr/local/bin/create-user.sh"
 manage_lease_script_url="$script_source_root/linux_host/manage-lease.sh"
 manage_lease_script="/usr/local/bin/manage-lease.sh"
+screensaver_settings_url="$script_source_root/linux_host/session_release_buffer/RHEL/00-screensaver"
+screensaver_locks_url="$script_source_root/linux_host/session_release_buffer/RHEL/screensaver"
 
 arch=$( /bin/arch )
 remoteAccessTool="both"  # Options: "xrdp", "xpra", or "both"
+
+# Disable the GNOME screen saver and screen lock on this host. Enabled by default because a
+# locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which
+# strands the host's lease. Set LINUXBROKER_DISABLE_SCREEN_LOCK=false to keep the lock screen.
+disableScreenLock="${LINUXBROKER_DISABLE_SCREEN_LOCK:-true}"
+disableScreenLock=$(printf '%s' "$disableScreenLock" | tr '[:upper:]' '[:lower:]')
+
+case "$disableScreenLock" in
+    true|1|yes|y) disableScreenLock="true" ;;
+    false|0|no|n) disableScreenLock="false" ;;
+    *)
+        echo "Unsupported LINUXBROKER_DISABLE_SCREEN_LOCK value: $disableScreenLock (expected true or false)"
+        exit 1
+        ;;
+esac
 
 orgId="${RHEL_ORG_ID:-}"
 activationKey="${RHEL_ACTIVATION_KEY:-}"
 
 output_directory="/usr/local/bin"
+dconf_local_directory="/etc/dconf/db/local.d"
+dconf_profile_file="/etc/dconf/profile/user"
 state_directory="/var/lib/linuxbroker-release-session"
 
 SCRIPT_PATH="$output_directory/release-session.sh"
@@ -296,5 +315,50 @@ else
     exit 1
 fi
 echo "avdadmin user is created and permissioned"
+
+# Disable screen lock on Gnome desktop
+if [ "$disableScreenLock" = "true" ]; then
+    echo "Disabling the Gnome Desktop screen saver and screen lock..."
+
+    sudo mkdir -p "$dconf_local_directory/locks"
+
+    echo "Downloading Gnome Desktop screen lock settings..."
+    if ! sudo wget -O "$dconf_local_directory/00-screensaver" "$screensaver_settings_url"; then
+        echo "ERROR: Failed to download screen lock settings from $screensaver_settings_url"
+        exit 1
+    fi
+
+    if ! sudo wget -O "$dconf_local_directory/locks/screensaver" "$screensaver_locks_url"; then
+        echo "ERROR: Failed to download screen lock overrides from $screensaver_locks_url"
+        exit 1
+    fi
+
+    sudo chmod 644 "$dconf_local_directory/00-screensaver" "$dconf_local_directory/locks/screensaver"
+
+    # A system dconf database is only consulted when a profile references it. RHEL does not
+    # ship /etc/dconf/profile/user, so without this the settings above are silently ignored.
+    sudo mkdir -p "$(dirname "$dconf_profile_file")"
+    if [ ! -s "$dconf_profile_file" ]; then
+        printf 'user-db:user\nsystem-db:local\n' | sudo tee "$dconf_profile_file" >/dev/null
+        echo "Created dconf profile $dconf_profile_file."
+    elif ! grep -qx 'system-db:local' "$dconf_profile_file"; then
+        # Guarantee a trailing newline before appending to an existing profile.
+        sudo sed -i -e '$a\' "$dconf_profile_file"
+        echo 'system-db:local' | sudo tee -a "$dconf_profile_file" >/dev/null
+        echo "Added system-db:local to existing dconf profile $dconf_profile_file."
+    else
+        echo "dconf profile $dconf_profile_file already references system-db:local."
+    fi
+    sudo chmod 644 "$dconf_profile_file"
+
+    if ! sudo dconf update; then
+        echo "ERROR: 'dconf update' failed; the screen lock settings were not applied."
+        exit 1
+    fi
+
+    echo "Gnome Desktop screen lock is disabled."
+else
+    echo "Skipping Gnome Desktop screen lock configuration (LINUXBROKER_DISABLE_SCREEN_LOCK=false)."
+fi
 
 echo "System configuration complete."

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -92,6 +92,7 @@ The checked-in [bicep/main.parameters.example.json](bicep/main.parameters.exampl
 - `linuxHostVmSize`: Linux host VM size.
 - `avdVmSize`: AVD host VM size.
 - `linuxHostOsVersion`: Linux image SKU.
+- `linuxHostDisableScreenLock`: `true` or `false`. Disables the GNOME screen saver and screen lock on RHEL hosts. Defaults to `true`. See [Linux Host Screen Lock](#linux-host-screen-lock).
 - `azureCloudName`: `AzurePublic`, `AzureUSGovernment`, or `AzureCustom`. See [Choosing The Target Azure Cloud](#choosing-the-target-azure-cloud).
 - `scriptSourceRoot`: root URL the Linux host bootstrap scripts are downloaded from.
 - `domainName`: domain suffix used by the broker when connecting to Linux hosts.
@@ -210,6 +211,65 @@ azd env set linuxHostSshPrivateKey $privateKey
 
 If you prefer to be prompted locally, leave both values unset and run `azd up` from an interactive terminal.
 
+## Linux Host Screen Lock
+
+RHEL hosts install the `Server with GUI` group, so they run a GNOME desktop. By default the
+bootstrap script disables the GNOME screen saver and screen lock on those hosts.
+
+This is on by default because a locked GNOME greeter inside an xrdp or xpra session frequently
+cannot be unlocked after a reconnect. When that happens the user cannot get back into the
+desktop, and the host stays leased until the lease is released manually.
+
+The configuration is applied through a dconf system database:
+
+| File on the host | Source in this repo |
+| --- | --- |
+| `/etc/dconf/db/local.d/00-screensaver` | [linux_host/session_release_buffer/RHEL/00-screensaver](../linux_host/session_release_buffer/RHEL/00-screensaver) |
+| `/etc/dconf/db/local.d/locks/screensaver` | [linux_host/session_release_buffer/RHEL/screensaver](../linux_host/session_release_buffer/RHEL/screensaver) |
+| `/etc/dconf/profile/user` | created by the bootstrap script |
+
+It sets `idle-delay` to `0` so the session never goes idle, sets `lock-enabled` to `false` so
+the screen saver never locks, and sets `disable-lock-screen` to `true` so the lock screen is
+removed entirely, including the `Super+L` shortcut and the `Lock` entry in the system menu. The
+lock list prevents users from changing any of those keys back.
+
+RHEL does not ship `/etc/dconf/profile/user`, and a system dconf database is only read when a
+profile references it, so the bootstrap script creates that file with `system-db:local`. An
+existing profile is preserved and only appended to.
+
+### Keeping the lock screen
+
+Set the parameter to `false` if you need to satisfy an idle screen lock control such as a DISA
+STIG or CIS benchmark:
+
+```powershell
+azd env set linuxHostDisableScreenLock false
+```
+
+The bootstrap script then skips the dconf configuration entirely and leaves the distribution
+defaults in place. You can also set `LINUXBROKER_DISABLE_SCREEN_LOCK=false` in the environment
+if you run `Configure-RHEL7-Host.sh`, `Configure-RHEL8-Host.sh`, or `Configure-RHEL9-Host.sh`
+by hand.
+
+This setting has no effect on the Ubuntu 24.04 image. That target uses the `server` SKU and does
+not install a desktop environment, so there is no GNOME screen lock to disable.
+
+### Verifying on a host
+
+```bash
+# The system database was built and is referenced by the profile.
+ls -l /etc/dconf/db/local
+grep system-db /etc/dconf/profile/user
+
+# The effective values, from inside a desktop session.
+gsettings get org.gnome.desktop.session idle-delay
+gsettings get org.gnome.desktop.screensaver lock-enabled
+gsettings get org.gnome.desktop.lockdown disable-lock-screen
+```
+
+Expect `uint32 0`, `false`, and `true`. If `gsettings` still reports the distribution defaults,
+check that `/etc/dconf/profile/user` contains `system-db:local` and rerun `sudo dconf update`.
+
 ## Quick Start
 
 From the repository root:
@@ -270,6 +330,7 @@ Important deployment characteristics:
 - The frontend and API App Services enable App Service health checks on `/health`.
 - The frontend and API apps are instrumented with Azure Monitor OpenTelemetry and receive `APPLICATIONINSIGHTS_CONNECTION_STRING` and `OTEL_SERVICE_NAME` through app settings.
 - Linux host auth defaults to `SSH`.
+- RHEL hosts have the GNOME screen saver and screen lock disabled unless `linuxHostDisableScreenLock` is `false`. See [Linux Host Screen Lock](#linux-host-screen-lock).
 - Key Vault stores `db-password` and `linux-host`.
 - The API app receives Key Vault Secrets User access so it can read those secrets at runtime.
 
@@ -475,6 +536,14 @@ Admin consent was likely not granted yet for the frontend delegated permissions 
 ### Linux hosts were provisioned but do not appear in SQL
 
 Rerun [Post-Provision.ps1](Post-Provision.ps1) after confirming SQL connectivity. Linux host SQL registration is intentionally limited to Linux hosts only.
+
+### A RHEL session is stuck on a lock screen that will not accept the password
+
+The GNOME lock screen inside an xrdp or xpra session often cannot be unlocked after a reconnect. Confirm the screen lock configuration actually applied on the host using the commands in [Linux Host Screen Lock](#linux-host-screen-lock). The most common cause is a missing `system-db:local` line in `/etc/dconf/profile/user`, which makes GNOME ignore the settings even though the files under `/etc/dconf/db/local.d/` are present.
+
+### The Custom Script Extension failed on the screen lock step
+
+The bootstrap script fails deliberately if it cannot download the dconf files or if `dconf update` fails, so the problem is visible instead of silently leaving the lock screen enabled. Check that `scriptSourceRoot` is reachable from the host, or set `linuxHostDisableScreenLock` to `false` to skip the step.
 
 ## Related Files
 

--- a/deploy/Initialize-DeploymentEnvironment.ps1
+++ b/deploy/Initialize-DeploymentEnvironment.ps1
@@ -978,6 +978,7 @@ Ensure-DefaultEnvValue -Key 'LINUX_HOST_SSH_PRIVATE_KEY' -ValueFactory { '' } | 
 Ensure-DefaultEnvValue -Key 'linuxHostSshPublicKey' -ValueFactory { Get-AzdEnvValue -Key 'LINUX_HOST_SSH_PUBLIC_KEY' } | Out-Null
 Ensure-DefaultEnvValue -Key 'linuxHostSshPrivateKey' -ValueFactory { Get-AzdEnvValue -Key 'LINUX_HOST_SSH_PRIVATE_KEY' } | Out-Null
 Ensure-DefaultEnvValue -Key 'linuxHostOsVersion' -ValueFactory { '24_04-lts' } | Out-Null
+Ensure-DefaultEnvValue -Key 'linuxHostDisableScreenLock' -ValueFactory { 'true' } | Out-Null
 Ensure-DefaultEnvValue -Key 'linuxHostVmSize' -ValueFactory { 'Standard_D2s_v5' } | Out-Null
 Ensure-DefaultEnvValue -Key 'avdVmSize' -ValueFactory { 'Standard_D8s_v5' } | Out-Null
 Ensure-DefaultEnvValue -Key 'avdMaxSessionLimit' -ValueFactory { '5' } | Out-Null
@@ -1096,6 +1097,7 @@ Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterNa
 Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'linuxHostCount' -Value (ConvertTo-IntParameterValue -Key 'linuxHostCount')
 Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'linuxHostAuthType' -Value (Get-RequiredAzdEnvValue -Key 'linuxHostAuthType')
 Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'linuxHostOsVersion' -Value (Get-RequiredAzdEnvValue -Key 'linuxHostOsVersion')
+Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'linuxHostDisableScreenLock' -Value (ConvertTo-BoolParameterValue -Key 'linuxHostDisableScreenLock' -DefaultValue $true)
 Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'avdHostPoolName' -Value (Get-RequiredAzdEnvValue -Key 'avdHostPoolName')
 Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'avdSessionHostCount' -Value (ConvertTo-IntParameterValue -Key 'avdSessionHostCount')
 Add-BicepParameterValue -ParameterCollection $bicepParameterEntries -ParameterName 'avdMaxSessionLimit' -Value (ConvertTo-IntParameterValue -Key 'avdMaxSessionLimit' -DefaultValue 5)

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -135,6 +135,9 @@ param linuxHostSshPublicKey string = ''
 @description('Linux host OS image SKU.')
 param linuxHostOsVersion string = '24_04-lts'
 
+@description('Disable the GNOME screen saver and screen lock on RHEL hosts. Enabled by default because a locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which strands the host lease. Set to false to keep the lock screen, for example to satisfy a STIG or CIS idle-lock control. Has no effect on the Ubuntu server image, which has no desktop.')
+param linuxHostDisableScreenLock bool = true
+
 @description('AVD host pool name.')
 param avdHostPoolName string = ''
 
@@ -211,6 +214,7 @@ module resources 'main.resources.bicep' = {
     linuxHostAuthType: linuxHostAuthType
     linuxHostSshPublicKey: linuxHostSshPublicKey
     linuxHostOsVersion: linuxHostOsVersion
+    linuxHostDisableScreenLock: linuxHostDisableScreenLock
     avdHostPoolName: avdHostPoolName
     avdSessionHostCount: avdSessionHostCount
     avdMaxSessionLimit: avdMaxSessionLimit

--- a/deploy/bicep/main.json
+++ b/deploy/bicep/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "10340234432767658268"
+      "templateHash": "18215410845754632442"
     }
   },
   "parameters": {
@@ -287,6 +287,13 @@
         "description": "Linux host OS image SKU."
       }
     },
+    "linuxHostDisableScreenLock": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Disable the GNOME screen saver and screen lock on RHEL hosts. Enabled by default because a locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which strands the host lease. Set to false to keep the lock screen, for example to satisfy a STIG or CIS idle-lock control. Has no effect on the Ubuntu server image, which has no desktop."
+      }
+    },
     "avdHostPoolName": {
       "type": "string",
       "defaultValue": "",
@@ -467,6 +474,9 @@
           "linuxHostOsVersion": {
             "value": "[parameters('linuxHostOsVersion')]"
           },
+          "linuxHostDisableScreenLock": {
+            "value": "[parameters('linuxHostDisableScreenLock')]"
+          },
           "avdHostPoolName": {
             "value": "[parameters('avdHostPoolName')]"
           },
@@ -490,7 +500,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "8084574638949372807"
+              "templateHash": "8583720927426092955"
             }
           },
           "parameters": {
@@ -666,6 +676,13 @@
                 "9-LVM",
                 "24_04-lts"
               ]
+            },
+            "linuxHostDisableScreenLock": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Disable the GNOME screen saver and screen lock on RHEL hosts. Set to false to keep the lock screen."
+              }
             },
             "avdHostPoolName": {
               "type": "string",
@@ -2308,6 +2325,9 @@
                   },
                   "scriptSourceRoot": {
                     "value": "[parameters('scriptSourceRoot')]"
+                  },
+                  "disableScreenLock": {
+                    "value": "[parameters('linuxHostDisableScreenLock')]"
                   }
                 },
                 "template": {
@@ -2317,7 +2337,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "2539702079136955532"
+                      "templateHash": "17206168761019900085"
                     }
                   },
                   "parameters": {
@@ -2387,6 +2407,13 @@
                       "metadata": {
                         "description": "Root URL the host bootstrap scripts are downloaded from. Point this at a reachable mirror for sovereign or air-gapped clouds."
                       }
+                    },
+                    "disableScreenLock": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Disable the GNOME screen saver and screen lock on RHEL hosts. Enabled by default because a locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which strands the host lease. Set to false to keep the lock screen, for example to satisfy a STIG or CIS idle-lock control. Has no effect on the Ubuntu server image, which has no desktop."
+                      }
                     }
                   },
                   "variables": {
@@ -2399,7 +2426,7 @@
                     ],
                     "normalizedScriptSourceRoot": "[if(endsWith(parameters('scriptSourceRoot'), '/'), take(parameters('scriptSourceRoot'), sub(length(parameters('scriptSourceRoot')), 1)), parameters('scriptSourceRoot'))]",
                     "bootstrapArgs": "[format('\"{0}\" \"{1}\"', parameters('linuxBrokerApiBaseUrl'), parameters('linuxBrokerApiClientId'))]",
-                    "bootstrapEnv": "[format('LINUXBROKER_SCRIPT_SOURCE_ROOT=\"{0}\"', variables('normalizedScriptSourceRoot'))]",
+                    "bootstrapEnv": "[format('LINUXBROKER_SCRIPT_SOURCE_ROOT=\"{0}\" LINUXBROKER_DISABLE_SCREEN_LOCK=\"{1}\"', variables('normalizedScriptSourceRoot'), if(parameters('disableScreenLock'), 'true', 'false'))]",
                     "adminCredentials": "[if(equals(parameters('authType'), 'Password'), createObject('adminPassword', parameters('adminPassword')), createObject())]",
                     "linuxConfiguration": "[if(equals(parameters('authType'), 'SSH'), createObject('disablePasswordAuthentication', true(), 'ssh', createObject('publicKeys', createArray(createObject('path', format('/home/{0}/.ssh/authorized_keys', parameters('adminUsername')), 'keyData', parameters('sshPublicKey'))))), createObject('disablePasswordAuthentication', false()))]",
                     "imageConfigs": {

--- a/deploy/bicep/main.parameters.example.json
+++ b/deploy/bicep/main.parameters.example.json
@@ -110,6 +110,9 @@
     "linuxHostOsVersion": {
       "value": "24_04-lts"
     },
+    "linuxHostDisableScreenLock": {
+      "value": true
+    },
     "avdHostPoolName": {
       "value": "linuxbroker-<environment-name>-hp"
     },

--- a/deploy/bicep/main.resources.bicep
+++ b/deploy/bicep/main.resources.bicep
@@ -71,6 +71,10 @@ param linuxHostSshPublicKey string = ''
   '24_04-lts'
 ])
 param linuxHostOsVersion string = '24_04-lts'
+
+@description('Disable the GNOME screen saver and screen lock on RHEL hosts. Set to false to keep the lock screen.')
+param linuxHostDisableScreenLock bool = true
+
 param avdHostPoolName string = ''
 param avdSessionHostCount int = 0
 param avdMaxSessionLimit int = 5
@@ -478,6 +482,7 @@ module linuxHosts 'modules/Linux/main.bicep' = if (deployLinuxHosts && linuxHost
     linuxBrokerApiBaseUrl: frontendApiBaseUrl
     linuxBrokerApiClientId: apiClientId
     scriptSourceRoot: scriptSourceRoot
+    disableScreenLock: linuxHostDisableScreenLock
   }
 }
 

--- a/deploy/bicep/modules/Linux/main.bicep
+++ b/deploy/bicep/modules/Linux/main.bicep
@@ -34,9 +34,12 @@ param OSVersion string
 @description('Root URL the host bootstrap scripts are downloaded from. Point this at a reachable mirror for sovereign or air-gapped clouds.')
 param scriptSourceRoot string = 'https://raw.githubusercontent.com/microsoft/LinuxBrokerForAVDAccess/refs/heads/main'
 
+@description('Disable the GNOME screen saver and screen lock on RHEL hosts. Enabled by default because a locked greeter inside an xrdp/xpra session often cannot be unlocked after a reconnect, which strands the host lease. Set to false to keep the lock screen, for example to satisfy a STIG or CIS idle-lock control. Has no effect on the Ubuntu server image, which has no desktop.')
+param disableScreenLock bool = true
+
 var normalizedScriptSourceRoot = endsWith(scriptSourceRoot, '/') ? take(scriptSourceRoot, length(scriptSourceRoot) - 1) : scriptSourceRoot
 var bootstrapArgs = '"${linuxBrokerApiBaseUrl}" "${linuxBrokerApiClientId}"'
-var bootstrapEnv = 'LINUXBROKER_SCRIPT_SOURCE_ROOT="${normalizedScriptSourceRoot}"'
+var bootstrapEnv = 'LINUXBROKER_SCRIPT_SOURCE_ROOT="${normalizedScriptSourceRoot}" LINUXBROKER_DISABLE_SCREEN_LOCK="${disableScreenLock ? 'true' : 'false'}"'
 
 var vmNames = [for i in range(1, numberOfVMs): '${vmNamePrefix}-${padLeft(i, 2, '0')}']
 var adminCredentials = authType == 'Password' ? {

--- a/linux_host/session_release_buffer/RHEL/00-screensaver
+++ b/linux_host/session_release_buffer/RHEL/00-screensaver
@@ -1,7 +1,18 @@
-# Disable screen saver
+# Disable the GNOME screen saver and screen lock on brokered Linux hosts.
+#
+# A locked GNOME greeter inside an xrdp/xpra session frequently cannot be unlocked
+# after a reconnect, which strands the host's lease until it is released manually.
+
+# Never treat the session as idle, so the screen saver never activates.
 [org/gnome/desktop/session]
 idle-delay=uint32 0
 
+# Do not lock when the screen saver or a blank screen does activate.
 [org/gnome/desktop/screensaver]
-lock-enabled=true
+lock-enabled=false
 lock-delay=uint32 0
+
+# Remove the lock screen entirely, including the Super+L shortcut and the
+# "Lock" entry in the system menu. Without this, a user can still lock manually.
+[org/gnome/desktop/lockdown]
+disable-lock-screen=true

--- a/linux_host/session_release_buffer/RHEL/screensaver
+++ b/linux_host/session_release_buffer/RHEL/screensaver
@@ -1,4 +1,6 @@
-# Lock desktop screensaver settings
+# Prevent users from re-enabling the screen saver or the lock screen.
+# Every key set in 00-screensaver is listed here so the values above are enforced.
 /org/gnome/desktop/session/idle-delay
 /org/gnome/desktop/screensaver/lock-enabled
 /org/gnome/desktop/screensaver/lock-delay
+/org/gnome/desktop/lockdown/disable-lock-screen


### PR DESCRIPTION
Fixes #11.

## Is this issue still worth pursuing?

Yes — but as a bug fix rather than a new feature. A partial implementation landed in 7d97374 ("adding Gnome Desktop screensaver and lock files"), which is why the issue looks done but was never closed. It was RHEL 8 only, effectively a no-op at runtime, and the "optional" part of the title was never built.

## The feature never actually worked

Two separate problems made it a silent no-op:

**1. The target directories were never created.** `Configure-RHEL8-Host.sh` wrote to `/etc/dconf/db/local.d/` and `/etc/dconf/db/local.d/locks/` with no `mkdir -p`. Those paths don't exist on a fresh RHEL host. The script has no `set -e` and checked no exit codes, so both writes failed, `dconf update` still ran, and the Custom Script Extension reported success.

Reproduced by running the original block from `main` against a fake root:

```
--- original block from HEAD ---
# Disable screen lock on Gnome desktop
echo "Downloading Gnome Desktop screen lock settings..."
sudo wget -O "$dconf_local_directory/00-screensaver" "$screensaver_settings_url"
sudo wget -O "$dconf_local_directory/locks/screensaver" "$screensaver_locks_url"
sudo dconf update
--- executing against a fake root ---
Downloading Gnome Desktop screen lock settings...
.../etc/dconf/db/local.d/00-screensaver: No such file or directory
.../etc/dconf/db/local.d/locks/screensaver: No such file or directory
(dconf update called)
block exit status: 0
settings file: MISSING
```

**2. No dconf profile referenced the local database.** A system dconf database is only read when a profile lists it. RHEL does not ship `/etc/dconf/profile/user`, and nothing in the repo created it, so GNOME ignored the `local` database even in the case where the files did land.

## The configuration was also wrong for its stated purpose

`00-screensaver` was commented "Disable screen saver" and invoked under "Disable screen lock", but set `lock-enabled=true`. It only avoided an auto-lock as a side effect of `idle-delay=0`. A manual `Super+L` still locked the session — which is the case that actually hurts here, because a locked GNOME greeter inside an xrdp/xpra session frequently cannot be unlocked after a reconnect, leaving the user stranded and the host lease held.

Worse, `lock-enabled` was in the lock list, so the *wrong* value was the one users were prevented from changing.

## Changes

- **Fix the dconf plumbing.** Create the directories, create `/etc/dconf/profile/user` with `system-db:local`, and fail loudly if a download or `dconf update` fails. An existing profile is preserved and appended to (with a guaranteed trailing newline first) rather than clobbered.
- **Fix the keys.** `lock-enabled=false` plus `lockdown/disable-lock-screen=true`, so the lock screen is removed rather than merely deferred. All four keys are locked.
- **Make it optional** (the issue title). New `LINUXBROKER_DISABLE_SCREEN_LOCK` env var, surfaced as the `linuxHostDisableScreenLock` bicep parameter and azd environment value. Defaults to `true`, preserving current behavior; set to `false` to satisfy a STIG or CIS idle-lock control.
- **Cover RHEL 7 and RHEL 9.** Both `groupinstall "Server with GUI"` and both are selectable `OSVersion` values, but neither had any screen lock configuration.
- **Document it** in `deploy/DEPLOYMENT.md`: a "Linux Host Screen Lock" section with the rationale, the opt-out, host-side verification commands, and two troubleshooting entries.

Ubuntu 24.04 is unaffected — that target is the `server` SKU with the desktop install commented out, so there is no GNOME lock to disable. Called out explicitly in the docs.

## Validation

The repo has no test suite for these shell scripts, so I wrote three throwaway harnesses (not committed) and ran them against the final state:

- **Toggle + profile logic** (22 checks) — case-insensitive `true`/`false`/`yes`/`no`/`1`/`0`, rejection of bad values, profile creation when absent, append when the existing file has no trailing newline, idempotency on re-run, preservation of an unrelated `system-db:site`, and cross-verification that every key set in `00-screensaver` appears in the lock list and vice versa.
- **End-to-end**, extracting the *shipped* block from each of the three scripts and executing it against a fake root with `sudo`/`wget`/`dconf` stubbed — verifies files land, the profile is written, `dconf update` runs, modes are 644, and that the disabled path installs nothing and logs the skip.
- **Env-var path**, driving each script's real toggle parser through the same `VAR=value bash script.sh` prefix form the ARM `commandToExecute` uses.

All passing. Also: `bash -n` clean on every shell script in the repo, `az bicep build` succeeds, the regenerated `main.json` is byte-identical on rebuild, and `Initialize-DeploymentEnvironment.ps1` parses.

`main.json` is regenerated with the same Bicep version (0.44.1) that produced the checked-in copy, so the diff is limited to the new parameter and the template hashes.